### PR TITLE
Examples/Console/ConsoleApp: copy appSettings.json to the output directory so that the executable binary could locate it by default.

### DIFF
--- a/examples/Console/ConsoleApp/ConsoleApp.csproj
+++ b/examples/Console/ConsoleApp/ConsoleApp.csproj
@@ -20,4 +20,10 @@
     <ProjectReference Include="..\..\..\src\OpenAI.Net\OpenAI.Net.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appSettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixed a minor issue on the building the Examples/ConsoleApp.  Copy appSettings.json to the output directory so that the executable binary could locate it by default.
Without this fix, the built binary could not locate the appSettings.json, so that setting the OpenAI:ApiKey with a valid key does not make it to work out of the box.
